### PR TITLE
Make it a correct libary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a directory that you specify.
 Create a file, like `style.php`:
 
 ```
-use ScssPhp\ScssPhp\Server;
+use ScssPhp\Server\Server;
 
 $directory = "stylesheets";
 
@@ -59,7 +59,7 @@ Here's an example of creating a SCSS server that outputs compressed CSS:
 
 ```
 use ScssPhp\ScssPhp\Compiler;
-use ScssPhp\ScssPhp\Server;
+use ScssPhp\Server\Server;
 
 $scss = new Compiler();
 $scss->setFormatter('ScssPhp\ScssPhp\Formatter\Compressed');

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,13 @@
 {
     "name": "scssphp/server",
     "description": "Server for on-the-fly .scss compilation",
-    "type": "project",
+    "type": "libary",
+    "autoload": {
+        "psr-4": { "ScssPhp\\Server\\": "src/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "ScssPhp\\Server\\Tests\\": "tests/" }
+    },
     "require": {
         "scssphp/scssphp": "^1.0"
     },

--- a/src/Server.php
+++ b/src/Server.php
@@ -9,7 +9,7 @@
  * @link http://scssphp.github.io/scssphp
  */
 
-namespace ScssPhp\ScssPhp;
+namespace ScssPhp\Server;
 
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\Exception\ServerException;

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -9,7 +9,7 @@
  * @link http://scssphp.github.io/scssphp
  */
 
-namespace ScssPhp\ScssPhp\Tests;
+namespace ScssPhp\Server\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ScssPhp\ScssPhp\Server;


### PR DESCRIPTION
I have made changes so you can use this server as an libary (as 1 I was used to do). 

The namespace was incorrect and it only worked when copied into vendor/scssphp/scssphp/.

Please merge it and make a new version.