### PR TITLE
Remove null as default

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -166,11 +166,11 @@ class Server
     /**
      * Get If-Modified-Since header from client request
      *
-     * @return string|null
+     * @return string
      */
     protected function getIfModifiedSinceHeader()
     {
-        $modifiedSince = null;
+        $modifiedSince = '';
 
         if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
             $modifiedSince = $_SERVER['HTTP_IF_MODIFIED_SINCE'];
@@ -186,11 +186,11 @@ class Server
     /**
      * Get If-None-Match header from client request
      *
-     * @return string|null
+     * @return string
      */
     protected function getIfNoneMatchHeader()
     {
-        $noneMatch = null;
+        $noneMatch = '';
 
         if (isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
             $noneMatch = $_SERVER['HTTP_IF_NONE_MATCH'];


### PR DESCRIPTION
Proposal to replace the default value for some variables from null to empty string. Reason - passing null to non-nullable internal function parameters is deprecated.

Source - https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation

Ran into this error after upgrading to PHP v.8.1 - this is thrown because getIfNoneMatchHeader() returns null
`Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated`